### PR TITLE
Add resume guix manifest.

### DIFF
--- a/resume-manifest.scm
+++ b/resume-manifest.scm
@@ -1,0 +1,10 @@
+;;; Missing package in guix:
+;; europasscv-bibliography
+(specifications->manifest
+  '("texlive-base"
+    "texlive-biblatex"
+    "texlive-charter"
+    "texlive-csquotes"
+    "texlive-helvetic"
+    "texlive-latex-babel"
+    "texlive-latex-hyperref"))


### PR DESCRIPTION
This adds a guix manifest to your resume. It's a must have :)

europasscv-bibliography is currently not packaged for guix.
Let's package it!

When I try to build `bonface_munyoki_cv.tex` I get the following error:

! LaTeX Error: File `glyphtounicode.tex' not found.

wdyt?

## References

https://tex.stackexchange.com/questions/123081/inputglyphtounicode-with-pdfgentounicode-1-creates-unwanted-hyperlinks-from

